### PR TITLE
Mazebuilder rail connection fix

### DIFF
--- a/Assets/Scripts/Maze Builder.cs
+++ b/Assets/Scripts/Maze Builder.cs
@@ -262,7 +262,7 @@ public class MazeBuilder : MonoBehaviour
                     {
                         if (manager.borderRailSouth != null)
                         {
-                            if (neighbourManager.borderRailSouth != null)
+                            if (neighbourManager.borderRailNorth != null)
                             {
                                 manager.borderRailSouth.neighbours[2] = neighbourManager.borderRailNorth;
                                 manager.borderRailSouth.AutoSetSprite();


### PR DESCRIPTION
Fixed a bug where rails wouldn't connect south between rooms